### PR TITLE
Add support for GNU/Hurd

### DIFF
--- a/internal/x509andr/root_hurd.go
+++ b/internal/x509andr/root_hurd.go
@@ -1,0 +1,14 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509andr
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+}

--- a/internal/x509andr/root_unix.go
+++ b/internal/x509andr/root_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build dragonfly freebsd linux nacl netbsd openbsd solaris
+// +build dragonfly freebsd hurd linux nacl netbsd openbsd solaris
 
 package x509andr
 

--- a/internal/x509andr/root_unix_test.go
+++ b/internal/x509andr/root_unix_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build dragonfly freebsd linux netbsd openbsd solaris
+// +build dragonfly freebsd hurd linux netbsd openbsd solaris
 
 package x509andr
 


### PR DESCRIPTION
- use the `root_unix` (and its test) module also on Hurd (as Unix platform)
- copy the `root_linux` module as `root_hurd`, keeping all the distribution paths (even Hurd is available only as Debian distribution) to keep the maintenance/diff minimal