### PR TITLE
fix: dropped signingblock errors

### DIFF
--- a/signingblock/signingblock.go
+++ b/signingblock/signingblock.go
@@ -258,10 +258,12 @@ func newSigningBlock(r io.ReadSeeker) (sblock *signingBlock, magic uint32, err e
 	size, err := r.Seek(0, io.SeekEnd)
 	if err != nil {
 		err = fmt.Errorf("failed to seek to the end of the APK file: %s", err.Error())
+		return
 	}
 
-	if _, err := r.Seek(0, io.SeekStart); err != nil {
+	if _, err = r.Seek(0, io.SeekStart); err != nil {
 		err = fmt.Errorf("failed to seek to the start of the APK file: %s", err.Error())
+		return
 	}
 
 	if size < 4 {


### PR DESCRIPTION
This picks up two dropped `err` variables in `signingblock`.