### PR TITLE
fix: dropped fullsailor pad error

### DIFF
--- a/fullsailor/pkcs7/pkcs7.go
+++ b/fullsailor/pkcs7/pkcs7.go
@@ -885,6 +885,9 @@ func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
 	}
 	mode := cipher.NewCBCEncrypter(block, iv)
 	plaintext, err := pad(content, mode.BlockSize())
+	if err != nil {
+		return nil, nil, err
+	}
 	cyphertext := make([]byte, len(plaintext))
 	mode.CryptBlocks(cyphertext, plaintext)
 
@@ -909,7 +912,7 @@ func encryptDESCBC(content []byte) ([]byte, *encryptedContentInfo, error) {
 // value is EncryptionAlgorithmDESCBC. To use a different algorithm, change the
 // value before calling Encrypt(). For example:
 //
-//     ContentEncryptionAlgorithm = EncryptionAlgorithmAES128GCM
+//	ContentEncryptionAlgorithm = EncryptionAlgorithmAES128GCM
 //
 // TODO(fullsailor): Add support for encrypting content with other algorithms
 func Encrypt(content []byte, recipients []*x509.Certificate) ([]byte, error) {


### PR DESCRIPTION
This fixes a dropped error in `fullsailor/pkcs7` where the protection against a block length of zero is silently ignored.

@Tasssadar 